### PR TITLE
adding support for quick pointer conversion

### DIFF
--- a/pointers.go
+++ b/pointers.go
@@ -3,8 +3,17 @@ package underscore
 // Convert values to pointers
 //
 // Instead of:
-// v = "value"
+// v := "value"
 // MyPointerVar = &v
+//
+// Or
+// v1 := "value1"
+// v2 := 100
+//
+//	obj := Obj{
+//		Field1: &v,
+//		Field2: &v2,
+//	}
 //
 // Use:
 // MyPointerVar = ToPointer("value")

--- a/pointers.go
+++ b/pointers.go
@@ -1,0 +1,13 @@
+package underscore
+
+// Convert values to pointers
+//
+// Instead of:
+// v = "value"
+// MyPointerVar = &v
+//
+// Use:
+// MyPointerVar = ToPointer("value")
+func ToPointer[T any](in T) *T {
+	return &in
+}

--- a/pointers_test.go
+++ b/pointers_test.go
@@ -1,0 +1,45 @@
+package underscore_test
+
+import (
+	"reflect"
+	"testing"
+
+	u "github.com/rjNemo/underscore"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPointers(t *testing.T) {
+	variable := 123
+	var object struct{}
+
+	cases := []struct {
+		value    any
+		expected bool
+	}{
+		{
+			value:    u.ToPointer("myValue"),
+			expected: true,
+		},
+		{
+			value:    u.ToPointer(variable),
+			expected: true,
+		},
+		{
+			value:    &variable,
+			expected: true,
+		},
+		{
+			value:    nil,
+			expected: false,
+		},
+		{
+			value:    u.ToPointer(object),
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		got := (reflect.ValueOf(c.value).Kind() == reflect.Ptr)
+		assert.Equal(t, c.expected, got)
+	}
+}


### PR DESCRIPTION
Adding support for quick pointer conversion.
This is much more helpful when setting up structs with pointer fields.

So that instead of:
```go
v := "value"
MyPointerVar = &v

// or

v1 := "value1"
v2 := 100
v3 := []string{}
obj := Obj {
  Field1: &v1,
  Field2: &v2,
  Field3: &v3,
}
```

We just use:
`MyPointerVar = u.ToPointer("value")`

```go
obj := Obj {
  Field1: u.ToPointer("value"),
  Field2: u.ToPointer(100),
  Field3: u.ToPointer([]string{}),
}
```

