### PR TITLE
[CHORE] bump docker golang version and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.24.2-alpine
 
 ENV CGO_ENABLED 0
 ENV GOOS linux

--- a/Dockerfile.doc
+++ b/Dockerfile.doc
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24.2-alpine AS builder
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ machine for development and testing purposes.
 
 ### Prerequisites
 
-You need at least `go1.18` for development. The project is shipped with a [Dockerfile](Dockerfile)
-based on `go1.18`.
+You need at least `go1.24` for development. The project is shipped with a [Dockerfile](Dockerfile)
+based on `go1.24`.
 
 If you prefer local development, navigate to the [official
-download page](https://go.dev/dl/) and install version `1.18` or beyond.
+download page](https://go.dev/dl/) and install version `1.24` or beyond.
 
 ### Installing
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/rjNemo/underscore
 
-go 1.23.3
+go 1.24.2
 
 require (
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e
+	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e h1:I88y4caeGeuDQxgdoFPUq097j7kNfw6uvuiNxUBfcBk=
-golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
+golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc h1:TS73t7x3KarrNd5qAipmspBDS1rkMcgVG/fS1aRb4Rc=
+golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc/go.mod h1:A+z0yzpGtvnG90cToK5n2tu8UJVP2XUATh+r+sfOOOc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
- updated go.mod and Dockerfile to be 1.24
```
go test ./...
ok  	github.com/rjNemo/underscore	0.223s
ok  	github.com/rjNemo/underscore/examples	0.484s
ok  	github.com/rjNemo/underscore/maps	0.331s
```