### PR TITLE
fix: add explicit panic for Last on empty slice

### DIFF
--- a/last.go
+++ b/last.go
@@ -1,7 +1,10 @@
 package underscore
 
-// Last returns the last element of the slice
+// Last returns the last element of the slice.
+// Panics if the slice is empty.
 func Last[T any](values []T) T {
-	n := len(values)
-	return values[n-1]
+	if len(values) == 0 {
+		panic("underscore.Last: empty slice")
+	}
+	return values[len(values)-1]
 }


### PR DESCRIPTION
## Summary
- Add explicit panic with clear error message for `Last()` on empty slices
- Update documentation to note panic behavior
- Existing tests already cover this edge case

## Changes
- `last.go`: Added length check and explicit panic with message "underscore.Last: empty slice"
- Updated doc comment to document panic behavior

## Testing
- All existing tests pass including `TestLastEmpty` which validates panic behavior
- Run: `go test -v -run TestLast`

## Related
Resolves Issue 13 from ACTION_PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)