### PR TITLE
feat: add Init function (all but last)

### DIFF
--- a/init.go
+++ b/init.go
@@ -1,0 +1,18 @@
+package underscore
+
+// Init returns all elements except the last one, and the last element separately.
+// Returns an empty slice and zero value if the input slice is empty.
+// Also known as "uncons from the right" or "snoc" inverse.
+func Init[T any](values []T) ([]T, T) {
+	var last T
+	if len(values) == 0 {
+		return []T{}, last
+	}
+	if len(values) == 1 {
+		return []T{}, values[0]
+	}
+
+	res := make([]T, len(values)-1)
+	copy(res, values[:len(values)-1])
+	return res, values[len(values)-1]
+}

--- a/init_test.go
+++ b/init_test.go
@@ -1,0 +1,65 @@
+package underscore_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	u "github.com/rjNemo/underscore"
+)
+
+func TestInit(t *testing.T) {
+	nums := []int{1, 2, 3, 4, 5}
+	init, last := u.Init(nums)
+	assert.Equal(t, []int{1, 2, 3, 4}, init)
+	assert.Equal(t, 5, last)
+}
+
+func TestInitEmpty(t *testing.T) {
+	init, last := u.Init([]int{})
+	assert.Equal(t, []int{}, init)
+	assert.Equal(t, 0, last)
+}
+
+func TestInitSingleElement(t *testing.T) {
+	init, last := u.Init([]int{42})
+	assert.Equal(t, []int{}, init)
+	assert.Equal(t, 42, last)
+}
+
+func TestInitTwoElements(t *testing.T) {
+	init, last := u.Init([]int{1, 2})
+	assert.Equal(t, []int{1}, init)
+	assert.Equal(t, 2, last)
+}
+
+func TestInitStrings(t *testing.T) {
+	words := []string{"hello", "world", "!"}
+	init, last := u.Init(words)
+	assert.Equal(t, []string{"hello", "world"}, init)
+	assert.Equal(t, "!", last)
+}
+
+func TestInitDoesNotMutate(t *testing.T) {
+	original := []int{1, 2, 3, 4, 5}
+	init, last := u.Init(original)
+
+	// Modify returned slice
+	init[0] = 999
+
+	// Original should be unchanged
+	assert.Equal(t, 1, original[0])
+	assert.Equal(t, 5, last)
+}
+
+func BenchmarkInit(b *testing.B) {
+	nums := make([]int, 1000)
+	for i := range nums {
+		nums[i] = i
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		u.Init(nums)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Init`: returns all elements except the last one, and the last element separately
- Useful for list destructuring from the right

## Implementation
- `init.go`: Init implementation with proper memory allocation
- Comprehensive tests including edge cases (empty, single, two elements)
- Non-mutating: returned slice is a copy
- Benchmark included

## Testing
```bash
go test -v -run TestInit
go test -bench=BenchmarkInit -benchmem
```

All tests pass.

## Examples
```go
Init([]int{1,2,3,4,5})    // ([1,2,3,4], 5)
Init([]int{42})           // ([], 42)
Init([]int{})             // ([], 0)
Init([]string{"a","b"})   // (["a"], "b")
```

## Related
Resolves Issue 17 from ACTION_PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)