### PR TITLE
feat: add Intersperse function

### DIFF
--- a/intersperse.go
+++ b/intersperse.go
@@ -1,0 +1,23 @@
+package underscore
+
+// Intersperse inserts a separator between each element of the slice.
+// Returns an empty slice if the input is empty.
+// Returns the original element if the input has only one element.
+//
+// Example: Intersperse([]int{1,2,3}, 0) → [1, 0, 2, 0, 3]
+func Intersperse[T any](values []T, separator T) []T {
+	if len(values) == 0 {
+		return []T{}
+	}
+	if len(values) == 1 {
+		return []T{values[0]}
+	}
+
+	// Result will have len(values) + (len(values)-1) elements
+	res := make([]T, 0, len(values)*2-1)
+	res = append(res, values[0])
+	for i := 1; i < len(values); i++ {
+		res = append(res, separator, values[i])
+	}
+	return res
+}

--- a/intersperse_test.go
+++ b/intersperse_test.go
@@ -1,0 +1,60 @@
+package underscore_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	u "github.com/rjNemo/underscore"
+)
+
+func TestIntersperse(t *testing.T) {
+	nums := []int{1, 2, 3, 4, 5}
+	result := u.Intersperse(nums, 0)
+	assert.Equal(t, []int{1, 0, 2, 0, 3, 0, 4, 0, 5}, result)
+}
+
+func TestIntersperseEmpty(t *testing.T) {
+	result := u.Intersperse([]int{}, 0)
+	assert.Equal(t, []int{}, result)
+}
+
+func TestIntersperseSingleElement(t *testing.T) {
+	result := u.Intersperse([]int{42}, 0)
+	assert.Equal(t, []int{42}, result)
+}
+
+func TestIntersperseTwoElements(t *testing.T) {
+	result := u.Intersperse([]int{1, 2}, 0)
+	assert.Equal(t, []int{1, 0, 2}, result)
+}
+
+func TestIntersperseStrings(t *testing.T) {
+	words := []string{"hello", "world", "!"}
+	result := u.Intersperse(words, ",")
+	assert.Equal(t, []string{"hello", ",", "world", ",", "!"}, result)
+}
+
+func TestIntersperseComma(t *testing.T) {
+	words := []string{"apple", "banana", "cherry"}
+	result := u.Intersperse(words, ",")
+	assert.Equal(t, []string{"apple", ",", "banana", ",", "cherry"}, result)
+}
+
+func TestIntersperseNegativeNumber(t *testing.T) {
+	nums := []int{1, 2, 3}
+	result := u.Intersperse(nums, -1)
+	assert.Equal(t, []int{1, -1, 2, -1, 3}, result)
+}
+
+func BenchmarkIntersperse(b *testing.B) {
+	nums := make([]int, 100)
+	for i := range nums {
+		nums[i] = i
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		u.Intersperse(nums, 0)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Intersperse`: inserts a separator element between each element of a slice

## Implementation
- `intersperse.go`: Intersperse implementation with pre-allocation for optimal performance
- Handles edge cases: empty, single element, two elements
- Comprehensive tests
- Benchmark included

## Testing
```bash
go test -v -run TestIntersperse
go test -bench=BenchmarkIntersperse -benchmem
```

All tests pass.

## Examples
```go
Intersperse([]int{1,2,3,4,5}, 0)           // [1,0,2,0,3,0,4,0,5]
Intersperse([]string{"a","b","c"}, ",")    // ["a",",","b",",","c"]
Intersperse([]int{42}, 0)                  // [42]
Intersperse([]int{}, 0)                    // []
```

## Use Cases
- Formatting lists with separators (CSV, comma-separated words)
- Building display strings
- Creating alternating patterns

## Related
Resolves Issue 18 from ACTION_PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)