### PR TITLE
feat: add Sliding window function

### DIFF
--- a/sliding.go
+++ b/sliding.go
@@ -1,0 +1,23 @@
+package underscore
+
+// Sliding creates a sliding window view of the slice with the specified window size.
+// Returns an empty slice if size is less than or equal to 0.
+// Returns an empty slice if size is greater than the slice length.
+//
+// Example: Sliding([]int{1,2,3,4,5}, 3) → [[1,2,3], [2,3,4], [3,4,5]]
+func Sliding[T any](values []T, size int) [][]T {
+	if size <= 0 || size > len(values) {
+		return [][]T{}
+	}
+
+	windowCount := len(values) - size + 1
+	res := make([][]T, 0, windowCount)
+
+	for i := 0; i <= len(values)-size; i++ {
+		window := make([]T, size)
+		copy(window, values[i:i+size])
+		res = append(res, window)
+	}
+
+	return res
+}

--- a/sliding_test.go
+++ b/sliding_test.go
@@ -1,0 +1,90 @@
+package underscore_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	u "github.com/rjNemo/underscore"
+)
+
+func TestSliding(t *testing.T) {
+	nums := []int{1, 2, 3, 4, 5}
+	result := u.Sliding(nums, 3)
+	expected := [][]int{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}}
+	assert.Equal(t, expected, result)
+}
+
+func TestSlidingEmpty(t *testing.T) {
+	result := u.Sliding([]int{}, 3)
+	assert.Equal(t, [][]int{}, result)
+}
+
+func TestSlidingSizeOne(t *testing.T) {
+	nums := []int{1, 2, 3}
+	result := u.Sliding(nums, 1)
+	expected := [][]int{{1}, {2}, {3}}
+	assert.Equal(t, expected, result)
+}
+
+func TestSlidingSizeEqualLength(t *testing.T) {
+	nums := []int{1, 2, 3}
+	result := u.Sliding(nums, 3)
+	expected := [][]int{{1, 2, 3}}
+	assert.Equal(t, expected, result)
+}
+
+func TestSlidingSizeGreaterThanLength(t *testing.T) {
+	nums := []int{1, 2, 3}
+	result := u.Sliding(nums, 5)
+	assert.Equal(t, [][]int{}, result)
+}
+
+func TestSlidingSizeZero(t *testing.T) {
+	nums := []int{1, 2, 3}
+	result := u.Sliding(nums, 0)
+	assert.Equal(t, [][]int{}, result)
+}
+
+func TestSlidingSizeNegative(t *testing.T) {
+	nums := []int{1, 2, 3}
+	result := u.Sliding(nums, -1)
+	assert.Equal(t, [][]int{}, result)
+}
+
+func TestSlidingTwoElements(t *testing.T) {
+	nums := []int{1, 2, 3, 4}
+	result := u.Sliding(nums, 2)
+	expected := [][]int{{1, 2}, {2, 3}, {3, 4}}
+	assert.Equal(t, expected, result)
+}
+
+func TestSlidingStrings(t *testing.T) {
+	words := []string{"a", "b", "c", "d"}
+	result := u.Sliding(words, 2)
+	expected := [][]string{{"a", "b"}, {"b", "c"}, {"c", "d"}}
+	assert.Equal(t, expected, result)
+}
+
+func TestSlidingDoesNotMutate(t *testing.T) {
+	original := []int{1, 2, 3, 4}
+	result := u.Sliding(original, 2)
+
+	// Modify a window
+	result[0][0] = 999
+
+	// Original should be unchanged
+	assert.Equal(t, 1, original[0])
+}
+
+func BenchmarkSliding(b *testing.B) {
+	nums := make([]int, 100)
+	for i := range nums {
+		nums[i] = i
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		u.Sliding(nums, 10)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Sliding`: creates sliding window views of a slice with specified window size

## Implementation
- `sliding.go`: Sliding implementation with pre-allocation
- Returns independent window copies (non-mutating)
- Handles edge cases: empty, size <= 0, size > length, size == length
- Comprehensive tests
- Benchmark included

## Testing
```bash
go test -v -run TestSliding
go test -bench=BenchmarkSliding -benchmem
```

All tests pass.

## Examples
```go
Sliding([]int{1,2,3,4,5}, 3)      // [[1,2,3], [2,3,4], [3,4,5]]
Sliding([]int{1,2,3,4}, 2)        // [[1,2], [2,3], [3,4]]
Sliding([]int{1,2,3}, 1)          // [[1], [2], [3]]
Sliding([]int{1,2,3}, 3)          // [[1,2,3]]
Sliding([]int{1,2,3}, 5)          // []
```

## Use Cases
- Moving averages in time series data
- N-gram generation in text processing
- Pattern matching across sequences
- Rolling window computations

## Related
Resolves Issue 19 from ACTION_PLAN.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)